### PR TITLE
GetSinks: handle exception if sink doesn't have address set #8

### DIFF
--- a/wirepas_mqtt_library/wirepas_network_interface.py
+++ b/wirepas_mqtt_library/wirepas_network_interface.py
@@ -341,8 +341,15 @@ class WirepasNetworkInterface:
                 continue
 
             for sink in gw.sinks:
-                if network_address is not None and sink['network_address'] != network_address:
-                    continue
+                if network_address is not None:
+                    # Sinks are filtered on network address
+                    try:
+                        if sink['network_address'] != network_address:
+                            continue
+                    except KeyError:
+                        # Network address is unset so doesn't match
+                        continue
+
                 sinks.append((gw.id, sink['sink_id'], sink))
 
         return sinks


### PR DESCRIPTION
In case getSinks has network_addess filter enabled, check against
filter cannot be made and sink must not be reported.