### PR TITLE
Clear gateway: add an api to easily clear a gateway

### DIFF
--- a/wirepas_mqtt_library/topic_helper.py
+++ b/wirepas_mqtt_library/topic_helper.py
@@ -168,3 +168,11 @@ class TopicParser:
             raise RuntimeError("Wrong topic for received_data")
 
         return gw_id, sink_id, int(network_id), int(src_ep), int(dst_ep)
+
+    @staticmethod
+    def parse_status_topic(topic):
+        _, cmd, gw_id = topic.split("/")
+        if not cmd.startswith("status"):
+            raise RuntimeError("Wrong topic for status")
+
+        return gw_id


### PR DESCRIPTION
In a normal setup, it shouldn't be needed but could be useful
during developement or when a gateway name has changed (to avoid
persisting an offline status forever)