### PR TITLE
Adding gateway status topics in mqtt.

### DIFF
--- a/wirepas_mqtt_library/topic_helper.py
+++ b/wirepas_mqtt_library/topic_helper.py
@@ -74,6 +74,10 @@ class TopicGenerator:
     def make_get_gateway_info_request_topic(gw_id):
         return TopicGenerator._make_request_topic("get_gw_info", [str(gw_id)])
 
+    @staticmethod
+    def make_get_gw_status_request_topic():
+        return TopicGenerator._make_request_topic("get_gw_status", [])
+
     ##################
     # Response Part
     ##################
@@ -124,6 +128,10 @@ class TopicGenerator:
     @staticmethod
     def make_get_gateway_info_response_topic(gw_id):
         return TopicGenerator._make_response_topic("get_gw_info", [str(gw_id)])
+
+    @staticmethod
+    def make_get_gw_status_response_topic(gw_id):
+        return TopicGenerator._make_response_topic("get_gw_status", [str(gw_id)])
 
     ##################
     # Event Part


### PR DESCRIPTION
New MQTT topics can be used in the case where the mqtt broker does not support retained message and we would like to know the status of the gateways as soon as possible.

The concerned topics in the mqtt broker are :
gw-request/get_gw_status
gw-response/get_gw_status/<gw-id>/<sink-id>