### PR TITLE
Uploading scratchpad: make timeout configurable

### DIFF
--- a/wirepas_mqtt_library/wirepas_network_interface.py
+++ b/wirepas_mqtt_library/wirepas_network_interface.py
@@ -639,7 +639,7 @@ class WirepasNetworkInterface:
         return self._wait_for_response(cb, request.req_id, param=param)
 
     @_wait_for_connection
-    def upload_scratchpad(self, gw_id, sink_id, seq, scratchpad=None, cb=None, param=None):
+    def upload_scratchpad(self, gw_id, sink_id, seq, scratchpad=None, cb=None, param=None, timeout=60):
         """
         upload_scratchpad(self, gw_id, sink_id, seq, scratchpad=None, cb=None, param=None)
         Upload a scratchpad on a given sink
@@ -663,22 +663,24 @@ class WirepasNetworkInterface:
             - gw_error_code: :obj:`~wirepas_mesh_messaging.gateway_result_code.GatewayResultCode`
             - param: param given when doing this call
 
-            .. warning:: If unset, call is synchronous and caller can be blocked for up to 60 seconds
+            .. warning:: If unset, call is synchronous and caller can be blocked for up to specified timeout
 
         :type cb: function
         :param param: Optional parameter that will be passed to callback
         :type param: object
+        :param timeout: Timeout in second to wait for the upload (default 60s)
+        :type timeout: int
         :return: None if cb is set or error code from gateway is synchronous call
         :rtype: :obj:`~wirepas_mesh_messaging.gateway_result_code.GatewayResultCode`
 
-        :raises TimeoutError: Raised if cb is None and response is not received within 60 sec
+        :raises TimeoutError: Raised if cb is None and response is not received within the specified timeout
         """
         request = wmm.UploadScratchpadRequest(seq, sink_id, scratchpad=scratchpad)
 
         self._publish(TopicGenerator.make_otap_load_scratchpad_request_topic(gw_id, sink_id),
                       request.payload,
                       1)
-        return self._wait_for_response(cb, request.req_id, timeout=60, param=param)
+        return self._wait_for_response(cb, request.req_id, timeout=timeout, param=param)
 
     @_wait_for_connection
     def process_scratchpad(self, gw_id, sink_id, cb=None, param=None):

--- a/wirepas_mqtt_library/wirepas_otap_helper.py
+++ b/wirepas_mqtt_library/wirepas_otap_helper.py
@@ -135,13 +135,15 @@ class WirepasOtapHelper:
 
         self._nodes[data.source_address] = new_status
 
-    def load_scratchpad_to_all_sinks(self, scratchpad_file, seq=None):
+    def load_scratchpad_to_all_sinks(self, scratchpad_file, seq=None, timeout=60):
         """Load the specified scratchpad file on all sinks of the network
 
         :param scratchpad_file: scratchpad file with .otap extension
         :type scratchpad_file: str
         :param seq: optional seq for the scratchpad. If not given a random one is chosen
         :type seq: int
+        :param timeout: maximum time to wait for each scratchpad upload
+        :type timeout: int
         :return: True if scratchpad is correctly loaded on all sinks, false otherwise
         """
         # Read the scratchpad file as binary
@@ -159,7 +161,7 @@ class WirepasOtapHelper:
         for gw, sink, config in self._sinks:
             logging.debug("Loading scratchpad to [%s][%s] " % (gw, sink))
             try:
-                res = self.wni.upload_scratchpad(gw, sink, seq, scratchpad)
+                res = self.wni.upload_scratchpad(gw, sink, seq, scratchpad, timeout=timeout)
                 if res != wmm.GatewayResultCode.GW_RES_OK:
                     logging.error("Scratchpad loaded error: [%s] " % res)
                     return False


### PR DESCRIPTION
The default 60s was too short on some MCU