### PR TITLE
WNI: make processing of scratchpad timeout configurable

### DIFF
--- a/wirepas_mqtt_library/wirepas_network_interface.py
+++ b/wirepas_mqtt_library/wirepas_network_interface.py
@@ -695,7 +695,7 @@ class WirepasNetworkInterface:
         return self._wait_for_response(cb, request.req_id, extra_timeout=timeout, param=param)
 
     @_wait_for_connection
-    def process_scratchpad(self, gw_id, sink_id, cb=None, param=None):
+    def process_scratchpad(self, gw_id, sink_id, cb=None, param=None, timeout=120):
         """
         process_scratchpad(self, gw_id, sink_id, cb=None, param=None)
         Process scratchpad on a given sink
@@ -715,22 +715,24 @@ class WirepasNetworkInterface:
             - gw_error_code: :obj:`~wirepas_mesh_messaging.gateway_result_code.GatewayResultCode`
             - param: param given when doing this call
 
-            .. warning:: If unset, call is synchronous and caller can be blocked for up to 60 seconds
+            .. warning:: If unset, call is synchronous and caller can be blocked for up to specified timeout
 
         :type cb: function
         :param param: Optional parameter that will be passed to callback
         :type param: object
+        :param timeout: Timeout in second to wait for the processing of scratchpad (default 120s)
+        :type timeout: int
         :return: None if cb is set or error code from gateway is synchronous call
         :rtype: :obj:`~wirepas_mesh_messaging.gateway_result_code.GatewayResultCode`
 
-        :raises TimeoutError: Raised if cb is None and response is not received within 60 sec
+        :raises TimeoutError: Raised if cb is None and response is not received within specified timeout
         """
         request = wmm.ProcessScratchpadRequest(sink_id)
 
         self._publish(TopicGenerator.make_otap_process_scratchpad_request_topic(gw_id, sink_id),
                       request.payload,
                       1)
-        return self._wait_for_response(cb, request.req_id, extra_timeout=60, param=param)
+        return self._wait_for_response(cb, request.req_id, extra_timeout=timeout, param=param)
 
     @_wait_for_connection
     def get_scratchpad_status(self, gw_id, sink_id, cb=None, param=None):

--- a/wirepas_mqtt_library/wirepas_otap_helper.py
+++ b/wirepas_mqtt_library/wirepas_otap_helper.py
@@ -196,16 +196,18 @@ class WirepasOtapHelper:
 
         return final_result
 
-    def process_scratchpad_on_all_sinks(self):
-        """Process the scratchpad locally on all sinks of the network
+    def process_scratchpad_on_all_sinks(self, timeout=120):
+        """Process the scratchpad localy on all sinks of the network
 
+        :param timeout: maximum time to wait for processing of scratchpad
+        :type timeout: int
         :return: True if scratchpad is correctly set to be processed on all sinks, false otherwise
         """
         logging.info("Processing scratchpad on all sinks for network %d" % self.network)
         for gw, sink, config in self._sinks:
             logging.debug("Processing scratchpad to [%s][%s] " % (gw, sink))
             try:
-                res = self.wni.process_scratchpad(gw, sink)
+                res = self.wni.process_scratchpad(gw, sink, timeout=timeout)
                 if res != wmm.GatewayResultCode.GW_RES_OK:
                     logging.error("Scratchpad processing error: [%s] " % res)
                     return False


### PR DESCRIPTION
It was done for loading but it also make sense for processing as it ca be very long also on some platforms