### PR TITLE
Fix for unexpected termination of worker threads

### DIFF
--- a/wirepas_mqtt_library/wirepas_network_interface.py
+++ b/wirepas_mqtt_library/wirepas_network_interface.py
@@ -1205,11 +1205,15 @@ class _TaskQueue(Queue):
         while True:
             try:
                 task, args, kwargs = self.get()
-                task(*args, **kwargs)
-            except TypeError as e:
                 # When a task is None in the queue and the task is invoked
                 # a type error is raised. This condition is used to terminate the Thread
-                break
+                
+                if task is None:
+                    break
+
+                task(*args, **kwargs)
+            except Exception as e:
+                logging.exception(e)
 
     def terminate(self):
         for worker_id in range(0,self._num_worker):


### PR DESCRIPTION
Problem:
When the `task(*args, **kwargs)` call was a valid function (not `None`) but had a `TypeError` it would cause the thread to terminate. This had caused gateway configs timeout on gateways that had in-fact responded in time. The unexpected exit on a TypeError without any logging made it very difficult to find the fault.

This change instead explicitly checks if the task is `None` prior to terminating. Otherwise, any errors that occur will be logged using `logging.exception` but the thread itself will continue processing work. This stops any unexpected terminations of worker threads if a `TypeError` occurs during processing. 

I've used the catch all `Exception` since I'd think most people would like things to continue processing if an error occurs on one job and can `try except exit` themselves if they would like things to stop. However, completely understand if you have a different opinion and would do away with it.

Cheers,
Edwin