### PR TITLE
Update wirepas-mesh-messaging to 1.3.0 and support setting CDD items

### DIFF
--- a/examples/example_set_cdd_item.py
+++ b/examples/example_set_cdd_item.py
@@ -1,0 +1,59 @@
+# Copyright 2025 Wirepas Ltd. All Rights Reserved.
+#
+# See file LICENSE.txt for full license details.
+#
+import argparse
+from wirepas_mqtt_library import WirepasNetworkInterface
+import wirepas_mesh_messaging as wmm
+import logging
+
+if __name__ == "__main__":
+    """Sets a configuration data item for all sinks of a given gateway
+    """
+    parser = argparse.ArgumentParser(fromfile_prefix_chars='@')
+    parser.add_argument('--host',
+                        help="MQTT broker address",
+                        required=True)
+    parser.add_argument('--port', default=8883,
+                        type=int,
+                        help="MQTT broker port")
+    parser.add_argument('--username',
+                        help="MQTT broker username")
+    parser.add_argument('--password',
+                        help="MQTT broker password")
+    parser.add_argument('--insecure',
+                        dest='insecure', action='store_true',
+                        help="MQTT use unsecured connection")
+
+    parser.add_argument('--gateway',
+                        help="ID of the gateway concerned by update",
+                        required=True)
+    parser.add_argument('--endpoint',
+                        type=lambda x: int(x, 0),
+                        help="CDD endpoint",
+                        required=True)
+    parser.add_argument('--payload',
+                        default="",
+                        help="CDD payload as a hex string")
+
+    args = parser.parse_args()
+
+    logging.basicConfig(format='%(levelname)s %(asctime)s %(message)s', level=logging.INFO)
+
+    wni = WirepasNetworkInterface(args.host,
+                                  args.port,
+                                  args.username,
+                                  args.password,
+                                  insecure=args.insecure)
+
+    for gw, sink, config in wni.get_sinks(gateway=args.gateway):
+        print("Set new configuration data item on %s:%s with endpoint: 0x%04X" % (gw, sink, args.endpoint))
+        try:
+            res = wni.set_configuration_data_item(gw, sink, args.endpoint, bytes.fromhex(args.payload))
+            if res != wmm.GatewayResultCode.GW_RES_OK:
+                print("Cannot set configuration data item on %s:%s res=%s" % (gw, sink, res))
+        except TimeoutError:
+            print("Timeout when setting configuration data item on %s:%s" % (gw, sink))
+
+    print("All done")
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-wirepas_mesh_messaging==1.2.6
+wirepas_mesh_messaging~=1.3.0
 paho_mqtt==1.5.1
 peewee~=3.17.6

--- a/wirepas_mqtt_library/topic_helper.py
+++ b/wirepas_mqtt_library/topic_helper.py
@@ -74,6 +74,18 @@ class TopicGenerator:
     def make_get_gateway_info_request_topic(gw_id):
         return TopicGenerator._make_request_topic("get_gw_info", [str(gw_id)])
 
+    @staticmethod
+    def make_set_configuration_data_item_request_topic(gw_id="+", sink_id="+"):
+        return TopicGenerator._make_request_topic(
+            "set_configuration_data_item", [str(gw_id), str(sink_id)]
+        )
+
+    @staticmethod
+    def make_get_configuration_data_item_request_topic(gw_id="+", sink_id="+"):
+        return TopicGenerator._make_request_topic(
+            "get_configuration_data_item", [str(gw_id), str(sink_id)]
+        )
+
     ##################
     # Response Part
     ##################
@@ -124,6 +136,18 @@ class TopicGenerator:
     @staticmethod
     def make_get_gateway_info_response_topic(gw_id):
         return TopicGenerator._make_response_topic("get_gw_info", [str(gw_id)])
+
+    @staticmethod
+    def make_set_configuration_data_item_response_topic(gw_id="+", sink_id="+"):
+        return TopicGenerator._make_response_topic(
+            "set_configuration_data_item", [str(gw_id), str(sink_id)]
+        )
+
+    @staticmethod
+    def make_get_configuration_data_item_response_topic(gw_id="+", sink_id="+"):
+        return TopicGenerator._make_response_topic(
+            "get_configuration_data_item", [str(gw_id), str(sink_id)]
+        )
 
     ##################
     # Event Part

--- a/wirepas_mqtt_library/wirepas_network_interface.py
+++ b/wirepas_mqtt_library/wirepas_network_interface.py
@@ -470,6 +470,10 @@ class WirepasNetworkInterface:
                         'target_scratchpad_and_action': response.target_scratchpad_and_action
                     }
                 additional_params = status
+            elif cmd == "set_configuration_data_item":
+                response = wmm.SetConfigurationDataItemResponse.from_payload(message.payload)
+            elif cmd == "get_configuration_data_item":
+                response = wmm.GetConfigurationDataItemResponse.from_payload(message.payload)
             else:
                 logging.debug("Untracked response type %s" % cmd)
                 return
@@ -1175,6 +1179,33 @@ class WirepasNetworkInterface:
 
     def __str__(self):
         return str(self._gateways)
+
+    @_wait_for_connection
+    def set_configuration_data_item(self, gw_id, sink_id, endpoint, payload, cb=None, param=None):
+        """
+        set_configuration_data_item(self, gw_id, sink_id, endpoint, payload, cb=None, param=None)
+        Set configuration data item on a sink
+
+        Call can be blocking or non-blocking depending on ``cb`` parameter.
+
+        :param gw_id: gateway id the sink is attached to
+        :param sink_id: id of the sink
+        :param endpoint: configuration data item endpoint.
+        :param payload: configuration data item payload.
+        :return: None if cb is set or error code from gateway if synchronous call
+        :rtype: :obj:`~wirepas_mesh_messaging.gateway_result_code.GatewayResultCode`
+
+        :raises TimeoutError: Raised if cb is None and response is not received within 2 sec
+
+        """
+        request = wmm.SetConfigurationDataItemRequest(sink_id,
+                                                      endpoint,
+                                                      payload)
+
+        self._publish(TopicGenerator.make_set_configuration_data_item_request_topic(gw_id, sink_id),
+                      request.payload,
+                      1)
+        return self._wait_for_response(cb, request.req_id, param=param)
 
 
 class _DataFilter:


### PR DESCRIPTION
Topics for getting individual configuration data items are added among the list of topics, but no support is added for that. This is because configuration data items are available in the sink configuration.